### PR TITLE
Update developer toolbar.

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 -r base.txt
 
-django-debug-toolbar==1.4
+django-debug-toolbar==1.7
 django-extensions==1.6.1
 honcho==0.6.6
 


### PR DESCRIPTION
Django developer toolbar had an unpinned requirement for
sqlparse. On fresh installs that leads to a TypeError
(process() takes exactly 3 arguments (2 given)) due to API change
in the sqlparse module.